### PR TITLE
feat: use BTreeMap to automatically sort by keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let classifier = BertTokenClassificationHead::load(vb, &config)?;
 
-    use itertools::Itertools; // create an ordered list of labels for the chosen classifier
-    let labels = config
-        .id2label
-        .iter()
-        .sorted_by_key(|(i, _)| *i)
-        .map(|(_, label)| label.to_string())
-        .collect::<Vec<_>>();
+    // retrieve an ordered list of labels for the chosen classifier
+    let labels = config.id2label.values().cloned().collect();
 
     let output = classifier.classify( // classify some text (or use `classifier.forward` to get the output tensor)
         "This is the text we'd like to classify.",

--- a/examples/bert/src/main.rs
+++ b/examples/bert/src/main.rs
@@ -101,12 +101,7 @@ impl Args {
         let config = std::fs::read_to_string(config_filename)?;
         let config: Config = serde_json::from_str(&config)?;
         let tokenizer = Tokenizer::from_file(&tokenizer_filename).map_err(E::msg)?;
-        let labels = config
-            .id2label
-            .iter()
-            .sorted_by_key(|(i, _)| *i)
-            .map(|(_, label)| label.to_string())
-            .collect::<Vec<_>>();
+        let labels = config.id2label.values().cloned().collect();
 
         let vb = if self.use_pth {
             VarBuilder::from_pth(&weights_filename, DTYPE, &device)?

--- a/examples/electra/src/main.rs
+++ b/examples/electra/src/main.rs
@@ -101,12 +101,7 @@ impl Args {
         let config = std::fs::read_to_string(config_filename)?;
         let config: Config = serde_json::from_str(&config)?;
         let tokenizer = Tokenizer::from_file(&tokenizer_filename).map_err(E::msg)?;
-        let labels = config
-            .id2label
-            .iter()
-            .sorted_by_key(|(i, _)| *i)
-            .map(|(_, label)| label.to_string())
-            .collect::<Vec<_>>();
+        let labels = config.id2label.values().cloned().collect();
 
         let vb = if self.use_pth {
             VarBuilder::from_pth(&weights_filename, DTYPE, &device)?

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ pub struct Config {
     pub use_cache: bool,
     pub classifier_dropout: Option<f32>,
     pub model_type: Option<String>,
-    pub id2label: HashMap<u32, String>,
+    pub id2label: BTreeMap<u32, String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]


### PR DESCRIPTION
### Changes
- Replaces `Config.id2label` from being a `HashMap` to a `BTreeMap`.
- `BTreeMap` automatically sorts by keys, so examples have changed to not explicitly sort labels.
- Documentation in the README has also been updated.